### PR TITLE
possible bugfix for multi-threading Applications

### DIFF
--- a/vesper_log/Logging.cpp
+++ b/vesper_log/Logging.cpp
@@ -12,7 +12,7 @@
 
 using namespace Vesper;
 
-int Logging::nextID = 1;
+volatile int Logging::nextID = 1;
 
 Logging::Logging(LoggingTypes::LoggingClientType typets)
 {

--- a/vesper_log/Logging.hpp
+++ b/vesper_log/Logging.hpp
@@ -54,7 +54,7 @@ class Logging {
          * The unique identification that will be
          * given to the next client
          */
-        static int nextID;
+        volatile static int nextID;
 
         /**
          * The unique identification


### PR DESCRIPTION
Atomic makes sure the int will not be cached.
